### PR TITLE
enable top-level import of bisum

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ This program traces 2 sparse-tensor (torch.tensor objects) via 3 Tracing-Prescri
 
 Let's begin by initializing the 2 tensors, we can initialize random-sparse-tensors 
 ```python
-from bisum.bisum import bisum
 import torch
+from bisum import bisum
 
 shape_A = torch.tensor([8,7,7,4,11,6])
 shape_B = torch.tensor([9,7,3,7,11,8])
@@ -25,15 +25,17 @@ C_einsum = bisum("iksndj, wklsdi -> njwl", A, B)
 C_ncon   = bisum([[-1,-2,-3,4,-5,6],[1,-2,3,-3,-5,-1]], A, B)
 C_adjmat = bisum(torch.tensor([[0,1,2,4],[5,1,3,4]]), A, B)
 
-print( torch.allclose(C_einsum, C_ncon) and torch.allclose(C_ncon, C_adjmat) )
+print(torch.allclose(C_einsum, C_ncon) and torch.allclose(C_ncon, C_adjmat))
 ```
 while the pure tensor-product, $\otimes$ is:
 ```python
+import numpy as np
+
 C_einsum = bisum("abcdef, ghijkl", A, B)
 C_ncon   = bisum([], A, B)
 C_adjmat = bisum(torch.tensor([]), A, B)
 
-print( np.allclose(C_einsum, C_ncon) and np.allclose(C_ncon, C_adjmat) )
+print(np.allclose(C_einsum, C_ncon) and np.allclose(C_ncon, C_adjmat))
 ```
 
 ## Install

--- a/bisum/__init__.py
+++ b/bisum/__init__.py
@@ -1,1 +1,53 @@
+"""
+bisum -- efficient sparse tensor contractions
+=============================================
 
+The :mod:`bisum` package implements sparse-tensor partial-trace operations with `PyTorch`_.
+The primary function for users is :func:`bisum`.
+
+This program traces 2 sparse-tensor (:class:`torch.tensor` objects) via 3 Tracing-Prescription:
+
+1. ``{einsum}`` string (like numpy, str, labelling each tensor axis)
+2. ``ncon`` (used in the tensor-network community, list of 1d int :class:`torch.tensor`, labelling each tensor axis)
+3. adjacency-matrix (as in :func:`numpy.tensordot`, ``(2,n)`` 2d int torch.tensor, with n being the number of indices identified between the two tensors)
+
+.. _`PyTorch`: https://pytorch.org/
+
+
+Quickstart
+----------
+
+Let's begin by initializing the 2 tensors, we can initialize random-sparse-tensors::
+
+    import torch
+    from bisum import bisum
+
+    shape_A = torch.tensor([8,7,7,4,11,6])
+    shape_B = torch.tensor([9,7,3,7,11,8])
+    A = torch.rand(shape_A)
+    B = torch.rand(shape_B)
+
+Suppose we would like to compute the following partial-trace/tensor-contraction :math:`C_{njwl} = A_{iksndj} B_{wklsdi}`::
+
+    C_einsum = bisum("iksndj, wklsdi -> njwl", A, B)
+    C_ncon   = bisum([[-1,-2,-3,4,-5,6],[1,-2,3,-3,-5,-1]], A, B)
+    C_adjmat = bisum(torch.tensor([[0,1,2,4],[5,1,3,4]]), A, B)
+
+    print(torch.allclose(C_einsum, C_ncon) and torch.allclose(C_ncon, C_adjmat))
+
+
+while the pure tensor-product, :math:`\otimes` is::
+
+    import numpy as np
+
+    C_einsum = bisum("abcdef, ghijkl", A, B)
+    C_ncon   = bisum([], A, B)
+    C_adjmat = bisum(torch.tensor([]), A, B)
+
+    print(np.allclose(C_einsum, C_ncon) and np.allclose(C_ncon, C_adjmat))
+
+"""
+
+from .bisum import bisum
+
+__all__ = ["bisum"]

--- a/bisum/tests/test_bisum.py
+++ b/bisum/tests/test_bisum.py
@@ -5,7 +5,7 @@ This python-file contains various tests for the bisum package.
 """
 
 import torch
-from bisum.bisum import bisum
+from bisum import bisum
 ###from dev_defs import sptensordot, sdtensordot
 
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")

--- a/bisum/tests/test_import.py
+++ b/bisum/tests/test_import.py
@@ -1,0 +1,17 @@
+# testing importing
+
+import types
+
+import bisum
+
+def test_top_level_import_bisum():
+    try:
+        from bisum import bisum
+    except ImportError:
+        raise AssertionError("Failed to import bisum from bisum")
+
+def test_top_level_bisum_function():
+    # check that this is really the function
+    if not isinstance(bisum.bisum, types.FunctionType):
+        raise AssertionError("bisum.bisum() is not a function")
+


### PR DESCRIPTION
- fix #6 
- use as `from bisum import bisum`
- NOTE: shadows the module bisum for users (so only in-package code can use `from .bisum import bisum`)
- added restructured text to __init__ (from README)
- adjusted imports in README example and in test_bisum.py
- added a pytest for testing the import